### PR TITLE
Improve ANSI support and --no-color

### DIFF
--- a/hello
+++ b/hello
@@ -18,7 +18,8 @@ from milc import cli
 def main(cli):
     comma = ',' if cli.config.general.comma else ''
     cli.log.debug('You used -v you lucky person!')
-    cli.log.info('Hello%s %s!', comma, cli.config.general.name)
+    cli.log.info('Hello%s %s, from cli.log.info!', comma, cli.config.general.name)
+    cli.echo('{fg_red}Hello%s %s, from cli.echo!', comma, cli.config.general.name)
 
 
 if __name__ == '__main__':

--- a/milc/ansi.py
+++ b/milc/ansi.py
@@ -68,6 +68,6 @@ class ANSIStrippingFormatter(ANSIEmojiLoglevelFormatter):
     """A log formatter that strips ANSI.
     """
     def format(self, record):
-        record.levelname = ansi_escape.sub('', record.levelname)
         msg = super(ANSIStrippingFormatter, self).format(record)
+        record.levelname = ansi_escape.sub('', record.levelname)
         return ansi_escape.sub('', msg)

--- a/milc/ansi.py
+++ b/milc/ansi.py
@@ -64,9 +64,10 @@ class ANSIEmojiLoglevelFormatter(ANSIFormatter):
         return super(ANSIEmojiLoglevelFormatter, self).format(record)
 
 
-class ANSIStrippingFormatter(ANSIFormatter):
+class ANSIStrippingFormatter(ANSIEmojiLoglevelFormatter):
     """A log formatter that strips ANSI.
     """
     def format(self, record):
+        record.levelname = ansi_escape.sub('', record.levelname)
         msg = super(ANSIStrippingFormatter, self).format(record)
         return ansi_escape.sub('', msg)

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -24,7 +24,7 @@ import argcomplete
 import colorama
 from appdirs import user_config_dir
 
-from .ansi import ANSIEmojiLoglevelFormatter, ANSIStrippingFormatter, ansi_colors, format_ansi
+from .ansi import ANSIEmojiLoglevelFormatter, ANSIStrippingFormatter, ansi_colors, ansi_escape, format_ansi
 from .configuration import Configuration, SubparserWrapper, get_argument_name, handle_store_boolean
 from .attrdict import AttrDict
 
@@ -87,6 +87,9 @@ class MILC(object):
 
         args = args or kwargs
         text = format_ansi(text)
+
+        if not self.config.general.color:
+            text = ansi_escape.sub('', text)
 
         print(text % args)
 


### PR DESCRIPTION
This changes `cli.echo()` so that it strips ANSI when --no-color is used, the same way `cli.log.*` works. It also adds support for emoji log symbols when --no-color is used.