### PR TITLE
don't install tests together with package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         maintainer_email=metadata['author-email'],
         long_description=Path('README.md').read_text(),
         long_description_content_type="text/markdown",
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(exclude=('tests',)),
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Console',


### PR DESCRIPTION
`find_packages()` currently also finds the `tests` directory and attempts to install it to `..../python/$VERSION/site-packages/tests`, where it is likely to collide with other packages making the same mistake. This change simply excludes the tests from the installation process.

See corresponding issue on the archlinux bugtracker: https://bugs.archlinux.org/task/68380