### PR TITLE
Fix cli.print_help() and cli.print_usage()

### DIFF
--- a/example
+++ b/example
@@ -20,9 +20,22 @@ def main(cli):
     cli.print_usage()
 
 
+@cli.argument('--print-usage', action='store_true', help='Show a usage summary')
+@cli.argument('--print-help', action='store_true', help='Alias for --help')
 @cli.argument('--comma', help='comma in output', action='store_boolean', default=True)
 @cli.subcommand('Say hello.')
 def hello(cli):
+    """Say hello.
+    """
+    # print_usage and print_help are here to help us test.
+    if cli.config.hello.print_usage:
+        cli.print_usage()
+        return True
+
+    if cli.config.hello.print_help:
+        cli.print_help()
+        return True
+
     comma = ',' if cli.config.hello.comma else ''
     cli.echo('{fg_green}Hello%s %s!', comma, cli.config.general.name)
 

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -161,9 +161,23 @@ class MILC(object):
         self.args = AttrDict()
         self._arg_parser = argparse.ArgumentParser(**kwargs)
         self.set_defaults = self._arg_parser.set_defaults
-        self.print_usage = self._arg_parser.print_usage
-        self.print_help = self._arg_parser.print_help
         self.release_lock()
+
+    def print_help(self, *args, **kwargs):
+        """Print a help message for the main program or subcommand, depending on context.
+        """
+        if self._entrypoint.__name__ in self.subcommands:
+            return self.subcommands[self._entrypoint.__name__].print_help(*args, **kwargs)
+
+        return self._arg_parser.print_help(*args, **kwargs)
+
+    def print_usage(self, *args, **kwargs):
+        """Print brief description of how the main program or subcommand is invoked, depending on context.
+        """
+        if self._entrypoint.__name__ in self.subcommands:
+            return self.subcommands[self._entrypoint.__name__].print_usage(*args, **kwargs)
+
+        return self._arg_parser.print_usage(*args, **kwargs)
 
     def completer(self, completer):
         """Add an argcomplete completer to this subcommand.
@@ -453,7 +467,7 @@ class MILC(object):
         return self._entrypoint(self)
 
     def entrypoint(self, description):
-        """Set the entrypoint for when no subcommand is provided.
+        """Decorator that marks the entrypoint for simple scripts without subcommands.
         """
         if self._inside_context_manager:
             raise RuntimeError('You must run this before cli()!')


### PR DESCRIPTION
These would incorrectly print the main command's help/usage text when a subcommand tried to use them. This PR fixes that.