### PR TITLE
Add version parameter to constructor

### DIFF
--- a/milc/milc.py
+++ b/milc/milc.py
@@ -34,7 +34,7 @@ from .attrdict import AttrDict
 class MILC(object):
     """MILC - An Opinionated Batteries Included Framework
     """
-    def __init__(self):
+    def __init__(self, version='unknown'):
         """Initialize the MILC object.
 
             version
@@ -55,7 +55,7 @@ class MILC(object):
         self.config = self.config_source = None
         self.config_file = None
         self.default_arguments = {}
-        self.version = 'unknown'
+        self.version = version
         self.platform = platform()
 
         # Figure out our program name


### PR DESCRIPTION
I couldn't find a way to add the version number to allow the use of the `-V/--version` parameter. After looking at the code, I found that I could do:
```py
from milc import cli
cli.version = 'v0.1.0'
cli.initialize_logging()
```
and get the version command to work correctly.

In `MILC`'s constructor, I can see that there is a comment that hints that the version string was once a parameter:
https://github.com/clueboard/milc/blob/ca2daed833ab42bb517b8deeff440d78a324220f/milc/milc.py#L37-L42

All this PR does is add that parameter to the constructor, so now this is possible:
```py
from milc import MILC
cli = MILC('v0.1.0')
```
---
Contribution guidelines:

* [x] Format your code: `yapf -i -r .`
* [ ] Generate docs: `./generate_docs`
* [ ] Add any new doc files to `docs/_summary.md`
* [x] Run tests: `./ci_tests`