### PR TITLE
Fix handling of store_boolean

### DIFF
--- a/milc/configuration.py
+++ b/milc/configuration.py
@@ -67,7 +67,7 @@ class SubparserWrapper(object):
         """
         if kwargs.get('action') == 'store_boolean':
             # Store boolean will call us again with the enable/disable flag arguments
-            return handle_store_boolean(self.cli, *args, **kwargs)
+            return handle_store_boolean(self, *args, **kwargs)
 
         self.cli.acquire_lock()
         argument_name = get_argument_name(self.cli, *args, **kwargs)
@@ -101,7 +101,7 @@ def handle_store_boolean(self, *args, **kwargs):
     disabled_args = None
     disabled_kwargs = kwargs.copy()
     disabled_kwargs['action'] = 'store_false'
-    disabled_kwargs['dest'] = get_argument_name(self, *args, **kwargs)
+    disabled_kwargs['dest'] = get_argument_name(getattr(self, 'cli', self), *args, **kwargs)
     disabled_kwargs['help'] = 'Disable ' + kwargs['help']
     kwargs['action'] = 'store_true'
     kwargs['help'] = 'Enable ' + kwargs['help']


### PR DESCRIPTION
No idea if this is the "best" fix, though it does resolve the issue i am having.


Subcommand is configured with
```python
@cli.argument('-f', '--force', action='store_true', help='Flag to overwrite current info.json')
@cli.argument('-r', '--update-repo', action='store_boolean', help='update repo')
@cli.argument('-s', '--update-submodules', action=argparse.BooleanOptionalAction, default=True, help='update submodules')
@cli.subcommand('Update everything QMK.')
def up(cli):
```

which produces...
```console
qmk up --help
usage: qmk up [-h] [-s | --update-submodules | --no-update-submodules] [-f]

optional arguments:
  -h, --help            show this help message and exit
  -s, --update-submodules, --no-update-submodules
                        update submodules (default: True)
  -f, --force           Flag to overwrite current info.json
```

and....
```console
qmk --help
usage: qmk [-h] [-V] [-v] [--datetime-fmt DATETIME_FMT] [--log-fmt LOG_FMT] [--log-file-fmt LOG_FILE_FMT] [--log-file-level {debug,info,warning,error,critical}] [--log-file LOG_FILE] [--color] [--no-color]
           [--config-file CONFIG_FILE] [-r] [--no-update-repo]
           {config,clone,setup,c2json,chibios-confmigrate,clean,compile,config,doctor,flash,generate-rgb-breathe-table,info,json2c,lint,list-keyboards,list-keymaps,new-keymap,status,up} ...

CLI wrapper for running QMK commands.

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         Display the version and exit
  -v, --verbose         Make the logging more verbose
  --datetime-fmt DATETIME_FMT
                        Format string for datetimes
  --log-fmt LOG_FMT     Format string for printed log output
  --log-file-fmt LOG_FILE_FMT
                        Format string for log file.
  --log-file-level {debug,info,warning,error,critical}
                        Logging level for log file.
  --log-file LOG_FILE   File to write log messages to
  --color               Enable color in output
  --no-color            Disable color in output
  --config-file CONFIG_FILE
                        The location for the configuration file
  -r, --update-repo     Enable update repo
  --no-update-repo      Disable update repo
```

Where the `store_boolean` argument is wrongly added to the parent command (and `argparse.BooleanOptionalAction` is handled as expected)