### PR TITLE
Workaround for ANSI colors in Windows cmd

### DIFF
--- a/milc/ansi.py
+++ b/milc/ansi.py
@@ -2,6 +2,7 @@
 """
 import sys
 import re
+import os
 import logging
 import colorama
 
@@ -51,6 +52,7 @@ class ANSIFormatterMixin(object):
     """A log formatter mixin that inserts ANSI color.
     """
     def format(self, record):
+        os.system('') # workaround for ansi colors - https://stackoverflow.com/a/51524239
         msg = super(ANSIFormatterMixin, self).format(record)
         return format_ansi(msg)
 


### PR DESCRIPTION
Kinda gross but moving over to here from qmk/qmk_cli#41 as the bodge wasn't deep enough.

Before
![image](https://user-images.githubusercontent.com/16520359/108612032-9bdec780-73dc-11eb-86a6-1c695522fc65.png)

After
![image](https://user-images.githubusercontent.com/16520359/108612042-a13c1200-73dc-11eb-98fa-8be1322e77f5.png)

Some context on the change - https://stackoverflow.com/a/51524239