### PR TITLE
Keep using argv[0] for the config file name

### DIFF
--- a/milc/__init__.py
+++ b/milc/__init__.py
@@ -26,7 +26,13 @@ from .milc import MILC
 def argv_name():
     """Returns the name of our program by examining argv.
     """
-    app_name = sys.argv[0][:-3] if sys.argv[0].endswith('.py') else sys.argv[0]
+    if sys.argv[0].endswith('.py'):
+        app_name = sys.argv[0][:-3]
+    elif sys.argv[0].endswith('.exe'):
+        app_name = sys.argv[0][:-4]
+    else:
+        app_name = sys.argv[0]
+
     return os.path.split(app_name)[-1]
 
 

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -267,9 +267,17 @@ class MILC(object):
             return Path(sys.argv[sys.argv.index('--config-file') + 1]).expanduser().resolve()
 
         filedir = user_config_dir(appname=self.prog_name, appauthor=self.author)
-        filename = '%s.ini' % self.prog_name
 
-        return Path(filedir, filename).resolve()
+        if sys.argv[0].endswith('.py'):
+            filename = sys.argv[0][:-3]
+        elif sys.argv[0].endswith('.exe'):
+            filename = sys.argv[0][:-4]
+        else:
+            filename = sys.argv[0]
+
+        ini_filename = '%s.ini' % os.path.basename(filename)
+
+        return Path(filedir, ini_filename).resolve()
 
     def argument(self, *args, **kwargs):
         """Decorator to call self.add_argument or self.<subcommand>.add_argument.


### PR DESCRIPTION
Before 1.4.0, the config file path (on Windows, at least) for QMK CLI looks something like this:
```
C:/Users/<username>/AppData/Local/QMK.EXE/qmk.exe/qmk.exe.ini
```

After 1.4.0, it looks like:
```
C:/Users/<username>/AppData/Local/unknown/qmk.exe/qmk.exe.ini
```
After adding a `set_metadata()` call:
```
C:/Users/<username>/AppData/Local/QMK/QMK CLI/QMK CLI.ini
```

I prefer this path change - the Toolbox also places itself under `%LocalAppData%/QMK` - but IMO the ini file name should stay as it was. I also fixed a bug (again IMO) where if the main program's file extension is `.exe`, it doesn't get chopped off as it would for `.py`.

Now:
```
C:/Users/<username>/AppData/Local/QMK/QMK CLI/qmk.ini
```