### PR TITLE
Add deprecation to arguments and commands (#38) 

### DIFF
--- a/docs/argument_parsing.md
+++ b/docs/argument_parsing.md
@@ -32,6 +32,16 @@ Sometimes you want an argument to be a CLI flag only, and to not have a correspo
 
 You can specify [argcomplete completers](https://kislyuk.github.io/argcomplete/#specifying-completers) for your arguments by passing `completers`. For more detail see the [argcomplete](argcomplete.md) page.
 
+### deprecated
+
+You can use the `deprecated` argument to mark a flag as deprecated. To use this you should set it to a string that will be displayed in --help. For example:
+
+    @argument('--old', action='store_true', deprecated='Use --new instead', help='The old action for my command.')
+
+This will result in the following help output:
+
+    --old       The old action for my command. [Deprecated]: Use --new instead
+
 ### action: store_boolean
 
 In addition to the normal set of `action=` arguments that you can pass to `@argument()`, you can also pass a new action called `store_boolean`. This action behaves like `store_true` except that it adds a corresponding `--no-<argument>` flag that the user can pass as well.

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -525,8 +525,7 @@ class MILC(object):
                 A one-line description to display in --help
 
             deprecated
-                When not None displays a warning with its when the entrypoint
-                is used
+                Deprecation message. When set the subcommand will marked as deprecated and this message will be displayed in the help output.
         """
         if self._inside_context_manager:
             raise RuntimeError('You must run this before cli()!')

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -189,11 +189,9 @@ class MILC(object):
         return self._arg_parser.print_usage(*args, **kwargs)
 
     def log_deprecated_warning(self, item_type, name, reason):
-        """Logs a warning with a custom message if a argument or command is
-           deprecated.
+        """Logs a warning with a custom message if a argument or command is deprecated.
         """
-        self.log.warning("Warning: %s '%s' is deprecated:\n\t%s",
-                         item_type, name, reason)
+        self.log.warning("Warning: %s '%s' is deprecated:\n\t%s", item_type, name, reason)
 
     def add_argument(self, *args, **kwargs):
         """Wrapper to add arguments and track whether they were passed on the command line.
@@ -523,8 +521,7 @@ class MILC(object):
         raise RuntimeError('No entrypoint provided!')
 
     def entrypoint(self, description, deprecated=None):
-        """Decorator that marks the entrypoint used when a subcommand is not
-           supplied.
+        """Decorator that marks the entrypoint used when a subcommand is not supplied.
         Args:
             description
                 A one-line description to display in --help
@@ -570,8 +567,8 @@ class MILC(object):
                 When True don't display this command in --help
 
             deprecated
-                When not None displays a warning with its when the subcommand
-                is used and appends note to description
+                Deprecation message. When set the subcommand will be marked as deprecated
+                and this message will be displayed in help output.
         """
         if self._inside_context_manager:
             raise RuntimeError('You must run this before the with statement!')

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -495,10 +495,8 @@ class MILC(object):
                 msg = self._deprecated_commands[name]
                 self.log_deprecated_warning('Subcommand', name, msg)
 
-        deprecated_args_passed = (
-            [arg.replace('-', '') for arg in sys.argv
-             if arg.replace('-', '') in self._deprecated_arguments]
-        )
+        deprecated_args_passed = [arg.replace('-', '') for arg in sys.argv if arg.replace('-', '') in self._deprecated_arguments]
+
         for arg in deprecated_args_passed:
             msg = self._deprecated_arguments[arg]
             self.log_deprecated_warning('Argument', arg, msg)


### PR DESCRIPTION
Adding new information to the help formatting methods in argparse proved quite difficult and as far as I can tell, I would have to either "monkey-patch" or do some messy inheritance. In the end, I just appended the deprecation to the help strings, which achieves the same thing, but it is less modular.

* Add dictionaries to store the names and reasons of deprecated keyword arguments and commands

* Append tag and message to help message

* Check for deprecated keyword arguments and commands when a command is run and log warning for each found

```python
# deprecation_example
# Adapted from example in repo
...

# Whole entrypoint is deprecated will warn anytime this cli is invoked
@cli.entrypoint('Start program', deprecated='We have implemented <new command> '
                + 'it is so much cooler')
def main(cli):
    cli.log.info('No subcommand specified!')
    cli.print_usage()

"""Examples:
PS C:\GitHub\milc> python .\deprecation_example
⚠ Warning: Entrypoint 'main' is deprecated:
        We have implemented <new command> it is so much cooler
ℹ No subcommand specified!
usage: deprecation_example [-h] [-V] [-v] [--datetime-fmt DATETIME_FMT] [--log-fmt LOG_FMT] [--log-file-fmt LOG_FILE_FMT]
                           [--log-file-level {debug,info,warning,error,critical}] [--log-file LOG_FILE] [--color] [--no-color] [--unicode] [--no-unicode] [--interactive]
                           [--config-file CONFIG_FILE]
                           {good-command,better-command} ...
python .\deprecation_example --help
usage: deprecation_example [-h] [-V] [-v] [--datetime-fmt DATETIME_FMT] [--log-fmt LOG_FMT] [--log-file-fmt LOG_FILE_FMT]
                           [--log-file-level {debug,info,warning,error,critical}] [--log-file LOG_FILE] [--color] [--no-color] [--unicode] [--no-unicode] [--interactive]
                           [--config-file CONFIG_FILE]
                           {good-command,better-command} ...
PS C:\GitHub\milc> python .\deprecation_example --help
Start program [Deprecated]: We have implemented <new command> it is so much cooler

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         Display the version and exit
  -v, --verbose         Make the logging more verbose
  --datetime-fmt DATETIME_FMT
                        Format string for datetimes
  --log-fmt LOG_FMT     Format string for printed log output
  --log-file-fmt LOG_FILE_FMT
                        Format string for log file.
  --log-file-level {debug,info,warning,error,critical}
                        Logging level for log file.
  --log-file LOG_FILE   File to write log messages to
  --color               Enable color in output
  --no-color            Disable color in output
  --unicode             Enable unicode loglevels
  --no-unicode          Disable unicode loglevels
  --interactive         Force interactive mode even when stdout is not a tty.
  --config-file CONFIG_FILE
                        The location for the configuration file

Sub-commands:
  {good-command,better-command}
    good-command        Print an emoji [Deprecated]: Use better-command instead
    better-command      Print a better emoji with a pet.
"""

# Warn when this subcommand is used
@cli.subcommand('Print an emoji', deprecated='Use better-command instead')
def good_command(cli):
    cli.echo('\nB^)\n')

""" Example:
PS C:\GitHub\milc> python .\deprecation_example good-command
⚠ Warning: Entrypoint 'main' is deprecated:
        We have implemented <new command> it is so much cooler
⚠ Warning: Subcommand 'good-command' is deprecated:
        Use better-command instead

B^)
"""

# Warn when --pup is passed
@cli.argument('--cat', help='Add on a cat', action='store_true')
@cli.argument('--dog', help='Add on a dog', action='store_true')
@cli.argument('--pup', help='Add on a puppy', action='store_true',
              deprecated='Replaced by --dog')
@cli.subcommand('Print a better emoji with a pet.')
def better_command(cli):
    """Say hello.
    """
    cli.echo('\n(⌐■_■)')
    if cli.config.better_command.dog:
        print('∪･ω･∪\n')
    elif cli.config.better_command.pup:
        print('∪･ω･∪\n')
    elif cli.config.better_command.cat:
        print('(=^･ω･^=)\n')

"""Examples:
PS C:\GitHub\milc> python .\deprecation_example better-command --dog
⚠ Warning: Entrypoint 'main' is deprecated:
        We have implemented <new command> it is so much cooler

(⌐■_■)
∪･ω･∪

PS C:\GitHub\milc> python .\deprecation_example better-command --pup
⚠ Warning: Entrypoint 'main' is deprecated:
        We have implemented <new command> it is so much cooler
⚠ Warning: Argument 'pup' is deprecated:
        Replaced by --dog

(⌐■_■)
∪･ω･∪

PS C:\GitHub\milc> python .\deprecation_example better-command --help
usage: deprecation_example better-command [-h] [--pup] [--dog] [--cat]

optional arguments:
  -h, --help  show this help message and exit
  --pup       Add on a puppy [Deprecated]: Replaced by --dog
  --dog       Add on a dog
  --cat       Add on a cat
"""
...
```