### PR TITLE
More robust detection for passed arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ milc.egg-info
 .idea
 venv
 site
+.venv

--- a/ci_tests
+++ b/ci_tests
@@ -37,7 +37,7 @@ def main(cli):
         build_ok = False
 
     cli.log.info('Running yapf...')
-    cmd = ['yapf', '-q', '-r', '--exclude', 'venv/**', '.']
+    cmd = ['yapf', '-q', '-r', '--exclude', 'venv/**', '--exclude', '.venv/**', '.']
     result = run(cmd, stdin=DEVNULL)
     if result.returncode != 0:
         build_ok = False

--- a/example
+++ b/example
@@ -35,6 +35,7 @@ def dashed_hello(cli):
 @cli.argument('--print-usage', action='store_true', help='Show a usage summary')
 @cli.argument('--print-help', action='store_true', help='Alias for --help')
 @cli.argument('--comma', help='comma in output', action='store_boolean', default=True)
+@cli.argument('--count', help='Number of times to say hello', type=int, default=1)
 @cli.subcommand('Say hello.')
 def hello(cli):
     """Say hello.
@@ -49,7 +50,8 @@ def hello(cli):
         return True
 
     comma = ',' if cli.config.hello.comma else ''
-    cli.echo('{fg_green}Hello%s %s!', comma, cli.config.general.name)
+    for i in range(cli.config.hello.count):
+        cli.echo('{fg_green}Hello%s %s!', comma, cli.config.general.name)
 
 
 @cli.argument('-e', '--env', completer=EnvironCompleter, help='Environment Variable')

--- a/milc/configuration.py
+++ b/milc/configuration.py
@@ -84,7 +84,7 @@ class SubparserWrapper(object):
             del kwargs['completer']
 
         self.cli.acquire_lock()
-        argument_name = get_argument_name(self.cli, *args, **kwargs)
+        argument_name = get_argument_name(self.cli._arg_parser, *args, **kwargs)
 
         if completer:
             self.subparser.add_argument(*args, **kwargs).completer = completer
@@ -104,13 +104,22 @@ class SubparserWrapper(object):
         self.cli.release_lock()
 
 
-def get_argument_name(self, *args, **kwargs):
+def get_argument_strings(arg_parser, *args, **kwargs):
+    """Takes argparse arguments and returns a list of argument strings or positional names.
+    """
+    try:
+        return arg_parser._get_optional_kwargs(*args, **kwargs)['option_strings']
+    except ValueError:
+        return [arg_parser._get_positional_kwargs(*args, **kwargs)['dest']]
+
+
+def get_argument_name(arg_parser, *args, **kwargs):
     """Takes argparse arguments and returns the dest name.
     """
     try:
-        return self._arg_parser._get_optional_kwargs(*args, **kwargs)['dest']
+        return arg_parser._get_optional_kwargs(*args, **kwargs)['dest']
     except ValueError:
-        return self._arg_parser._get_positional_kwargs(*args, **kwargs)['dest']
+        return arg_parser._get_positional_kwargs(*args, **kwargs)['dest']
 
 
 def handle_store_boolean(self, *args, **kwargs):
@@ -119,7 +128,7 @@ def handle_store_boolean(self, *args, **kwargs):
     disabled_args = None
     disabled_kwargs = kwargs.copy()
     disabled_kwargs['action'] = 'store_false'
-    disabled_kwargs['dest'] = get_argument_name(getattr(self, 'cli', self), *args, **kwargs)
+    disabled_kwargs['dest'] = get_argument_name(getattr(self, 'cli', self)._arg_parser, *args, **kwargs)
     disabled_kwargs['help'] = 'Disable ' + kwargs['help']
     kwargs['action'] = 'store_true'
     kwargs['help'] = 'Enable ' + kwargs['help']

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ format = pylint
 max_line_length = 200
 exclude = 
 	venv
+	.venv
 ignore = 
 	E226
 	E501

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,31 @@
+"""Unit tests for milc.configuration.
+"""
+import argparse
+
+import milc.configuration
+
+arg_parser = argparse.ArgumentParser(description='Minimal argparser.')
+
+
+def test_get_argument_names_optional():
+    """Make sure we can get optional names from get_argument_strings.
+    """
+    assert milc.configuration.get_argument_name(arg_parser, '-v', '--verbose') == 'verbose'
+
+
+def test_get_argument_names_positional():
+    """Make sure we can get positional names from get_argument_strings.
+    """
+    assert milc.configuration.get_argument_name(arg_parser, 'files') == 'files'
+
+
+def test_get_argument_strings_optional():
+    """Make sure we can get optional names from get_argument_strings.
+    """
+    assert milc.configuration.get_argument_strings(arg_parser, '-v', '--verbose') == ['-v', '--verbose']
+
+
+def test_get_argument_strings_positional():
+    """Make sure we can get positional names from get_argument_strings.
+    """
+    assert milc.configuration.get_argument_strings(arg_parser, 'files') == ['files']

--- a/tests/test_script_example.py
+++ b/tests/test_script_example.py
@@ -43,14 +43,41 @@ def test_example_config():
         os.remove(tempfile)
 
 
+def test_numeric_arguments():
+    fd, tempfile = mkstemp()
+
+    try:
+        os.close(fd)
+
+        # Set the count
+        result = check_command('./example', '--no-color', '--config-file', tempfile, 'config', 'hello.count=2')
+        check_returncode(result)
+        check_assert(result, 'hello.count: 1 -> 2' in result.stdout)
+
+        # Make sure we get 2 prints
+        result = check_command('./example', '--no-color', '--config-file', tempfile, 'hello')
+        check_returncode(result)
+        print(repr(result.stdout))
+        check_assert(result, result.stdout == 'Hello, World!\nHello, World!\n')
+
+        # Make sure we get 1 prints
+        result = check_command('./example', '--no-color', '--config-file', tempfile, 'hello', '--count', '1')
+        check_returncode(result)
+        print(repr(result.stdout))
+        check_assert(result, result.stdout == 'Hello, World!\n')
+
+    finally:
+        os.remove(tempfile)
+
+
 def test_example_hello():
-    result = check_command('./example', 'hello')
+    result = check_command('./example', '--config-file', '/dev/null', 'hello')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello, World!\n')
 
 
 def test_example_hello_help():
-    result = check_command('./example', 'hello', '--help')
+    result = check_command('./example', '--config-file', '/dev/null', 'hello', '--help')
     check_returncode(result)
     check_assert(result, '[--no-comma]' in result.stdout)
     check_assert(result, '[--print-help]' in result.stdout)
@@ -58,37 +85,37 @@ def test_example_hello_help():
 
 
 def test_example_hello_no_color():
-    result = check_command('./example', '--no-color', 'hello')
+    result = check_command('./example', '--no-color', '--config-file', '/dev/null', 'hello')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello, World!\n')
 
 
 def test_example_hello_no_color_no_unicode():
-    result = check_command('./example', '--no-color', '--no-unicode', 'hello')
+    result = check_command('./example', '--no-color', '--no-unicode', '--config-file', '/dev/null', 'hello')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello, World!\n')
 
 
 def test_example_hello_no_color_no_comma():
-    result = check_command('./example', '--no-color', 'hello', '--no-comma')
+    result = check_command('./example', '--no-color', '--config-file', '/dev/null', 'hello', '--no-comma')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello World!\n')
 
 
 def test_example_hello_no_color_no_unicode_no_comma():
-    result = check_command('./example', '--no-color', '--no-unicode', 'hello', '--no-comma')
+    result = check_command('./example', '--no-color', '--no-unicode', '--config-file', '/dev/null', 'hello', '--no-comma')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello World!\n')
 
 
 def test_example_dashed_hello():
-    result = check_command('./example', 'dashed-hello')
+    result = check_command('./example', '--config-file', '/dev/null', 'dashed-hello')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello, dashed-subcommand World!\n')
 
 
 def test_example_dashed_hello_dashed_name():
-    result = check_command('./example', 'dashed-hello', '--dashed-name', 'Tester')
+    result = check_command('./example', '--config-file', '/dev/null', 'dashed-hello', '--dashed-name', 'Tester')
     check_returncode(result)
     check_assert(result, result.stdout == 'Hello, dashed-subcommand Tester!\n')
 


### PR DESCRIPTION
A user reported a bug- if you set a configuration option and then pass the default value on the command line MILC will incorrectly select the configuration value rather than the command line value. This PR improves argument detection to avoid that.