### PR TITLE
config file relative to config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ milc.egg-info
 venv
 site
 .venv
+.vscode/


### PR DESCRIPTION
I found it convenient to accept a value for `--config-file` that is a filename relative to the computed config dir. My goal was to conserve characters and the width of one-liners because my use case involves a lot of switching between config files.

Additionally, by allowing a basename without the `.ini` suffix I can use the `--config-file` option like a profile switcher e.g. `--config-file=staging` where the full path is like `~/.config/mycli/staging.ini`. We could instead move this "basename" functionality to a new option like `--profile` with a few more lines of code if you don't like the idea of overloading the behavior of `--config-file`.