### PR TITLE
Fix the `milc.cli.subcommand_name` property value

### DIFF
--- a/milc/milc_interface.py
+++ b/milc/milc_interface.py
@@ -84,8 +84,8 @@ class MILCInterface:
         return self.milc.subcommands
 
     @property
-    def subcommand_name(self) -> Any:
-        return self.milc._subcommand
+    def subcommand_name(self) -> Optional[str]:
+        return self.milc.subcommand_name
 
     def echo(self, text: str, *args: Any, **kwargs: Any) -> None:
         """Print colorized text to stdout.


### PR DESCRIPTION
The implementation of the `subcommand_name` property in `MILCInterface` was wrong (it actually returned the `_subcommand` function object instead of the subcommand name).