### PR TITLE
Add layered configuration files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ The human author of a change is fully responsible for its correctness, scope, an
 
 Agents and humans alike must follow the canonical project documentation, which can be found as markdown (.md) files in the repo, particularly under /docs. This file does not define separate rules for AI systems; it clarifies that no such separate rules exist.
 
+In particular, you must have read README.md and CODESTYLE.md, and you must check docs/ when necessary.
+
 # Scope and autonomy limits
 
 AI tools must not:

--- a/docs/api_milc.md
+++ b/docs/api_milc.md
@@ -21,7 +21,8 @@ def __init__(name: Optional[str] = None,
              author: Optional[str] = None,
              version: Optional[str] = None,
              logger: Optional[logging.Logger] = None,
-             env_prefix: Optional[str] = None) -> None
+             env_prefix: Optional[str] = None,
+             config_file: Optional[Union[str, Path]] = None) -> None
 ```
 
 Initialize the MILC object.
@@ -281,10 +282,10 @@ Save a single config option to the config file.
 #### save\_config
 
 ```python
-def save_config() -> None
+def save_config(config_file: Optional[Union[str, Path]] = None) -> None
 ```
 
-Save the current configuration to the config file.
+Save the current configuration to the config file or an explicit path.
 
 <a id="milc.MILC.__call__"></a>
 

--- a/docs/api_milc_interface.md
+++ b/docs/api_milc_interface.md
@@ -24,7 +24,8 @@ def milc_options(*,
                  author: Optional[str] = None,
                  version: Optional[str] = None,
                  logger: Optional[Logger] = None,
-                 env_prefix: Optional[str] = None) -> None
+                 env_prefix: Optional[str] = None,
+                 config_file: Optional[Union[str, Path]] = None) -> None
 ```
 
 Configure MILC before the entrypoint runs.
@@ -38,6 +39,7 @@ Call this before `cli()` or any imports that reference `cli`. It may be called m
 - `version` - The version string reported by `--version`.
 - `logger` - A custom logger instance to use instead of MILC's default logger.
 - `env_prefix` - A string prefix that enables environment variable defaults. When set, each `--flag` can be configured via a `<PREFIX>_<FLAG>` environment variable.
+- `config_file` - A system configuration file to read before the platformdirs user configuration file.
 
 <a id="milc_interface.MILCInterface.subcommand_name"></a>
 
@@ -184,10 +186,10 @@ Decorator to add an argument to a MILC command or subcommand.
 #### save\_config
 
 ```python
-def save_config() -> None
+def save_config(config_file: Optional[Union[str, Path]] = None) -> None
 ```
 
-Save the current configuration to the config file.
+Save the current configuration to the config file or an explicit path.
 
 <a id="milc_interface.MILCInterface.__call__"></a>
 

--- a/docs/api_subcommand_config.md
+++ b/docs/api_subcommand_config.md
@@ -53,6 +53,10 @@ Set a config key in the running config.
                    '--all',
                    action='store_true',
                    help='Show all configuration options.')
+@milc.cli.argument('-o',
+                   '--output',
+                   arg_only=True,
+                   help='Write the current configuration to this file.')
 @milc.cli.argument('-ro',
                    '--read-only',
                    arg_only=True,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ You can create new values by simply assigning to them. This only works with dict
 
 # Writing Configuration Files
 
-Use `cli.save_config()` to save the user's configuration file. It will be written to the location specified by `cli.config_file`.
+Use `cli.save_config()` to save the user's configuration file. It writes to the platformdirs location specified by `cli.config_file`, unless `--config-file` was supplied. Pass a path to `cli.save_config(path)` to write the current configuration elsewhere.
 
 # Configuration File Location
 
@@ -52,6 +52,16 @@ This will (usually) result in the following config file locations:
 * Linux: `~/.config/Florzelbop`
 * macOS: `~/Library/Application Support/Florzelbop`
 * Windows: `C:\Users\<User>\AppData\Local\Florzelbop\Florzelbop`
+
+# System Configuration File
+
+Applications can read a system configuration file before the platformdirs user configuration file:
+
+```python
+cli.milc_options(config_file='/etc/florzelbop.ini')
+```
+
+When the system file exists, MILC reads it first. It then always reads the platformdirs user config, whose settings override matching system settings. `cli.config_file` remains the platformdirs location, and `cli.save_config()` writes there. An explicit `--config-file` command-line argument instead reads and writes only that path, bypassing both layered locations.
 
 # Where Did A Value Come From?
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ You can create new values by simply assigning to them. This only works with dict
 
 # Writing Configuration Files
 
-Use `cli.save_config()` to save the user's configuration file. It writes to the platformdirs location specified by `cli.config_file`, unless `--config-file` was supplied. Pass a path to `cli.save_config(path)` to write the current configuration elsewhere.
+Use `cli.save_config()` to save the user's configuration file. It writes to the user's config location specified by `cli.config_file`, unless `--config-file` was supplied. Pass a path to `cli.save_config(path)` to write the current configuration elsewhere.
 
 # Configuration File Location
 
@@ -58,7 +58,7 @@ This will (usually) result in the following config file locations:
 Applications can read a system configuration file before the platformdirs user configuration file:
 
 ```python
-cli.milc_options(config_file='/etc/florzelbop.ini')
+cli.milc_options(config_file='/etc/my_app.conf')
 ```
 
 When the system file exists, MILC reads it first. It then always reads the platformdirs user config, whose settings override matching system settings. `cli.config_file` remains the platformdirs location, and `cli.save_config()` writes there. An explicit `--config-file` command-line argument instead reads and writes only that path, bypassing both layered locations.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -19,6 +19,7 @@ You should only do this once, and you should do it as early in your program's ex
 * `author` — The author string, used in the config file path on some platforms.
 * `logger` — A custom logger instance to use instead of MILC's default logger.
 * `env_prefix` — A string prefix that enables [environment variable defaults](environment_variables.md). When set, each `--flag` can be configured via a `<PREFIX>_<FLAG>` environment variable. See [Environment Variables](environment_variables.md) for full details.
+* `config_file` — A system configuration file to read before the platformdirs user configuration file. The user configuration overrides matching settings. `--config-file` bypasses both and uses only its supplied path.
 
 !!! warning
     If you have spread your program among several files, or you are using `milc.subcommand.config`, you need to use `cli.milc_options()` before you import those modules.

--- a/docs/subcommand_config.md
+++ b/docs/subcommand_config.md
@@ -106,6 +106,12 @@ You can read configuration values for all set options, the entire configuration,
 
     my_cli config user general.verbose general.log_format
 
+## Exporting Configuration
+
+Use `--output` (or `-o`) to write the current configuration to another file. This does not change the normal platformdirs save location:
+
+    my_cli config --output /path/to/config.ini
+
 ## Deleting Configuration Values
 
 You can delete a configuration value by setting it to the special string `None`.

--- a/milc/configuration.py
+++ b/milc/configuration.py
@@ -1,3 +1,6 @@
+from configparser import RawConfigParser
+from decimal import Decimal
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Hashable, List, Tuple
 
 if TYPE_CHECKING:
@@ -76,6 +79,37 @@ def _config_navigate(config_root: 'Configuration', dotted_path: str) -> 'Configu
             section._data[part] = new_section
             section = new_section
     return section
+
+
+def _read_config_file(config_file: Path, config: Configuration, config_source: Configuration) -> None:
+    """Merge a configuration file into the running configuration."""
+    raw_config = RawConfigParser()
+
+    raw_config.read(str(config_file))
+
+    # Iterate over the config file options and write them into config.
+    # Section names may be dotted (e.g. [remote.add]) for nested subcommands.
+    for section in raw_config.sections():
+        config_section = _config_navigate(config, section)
+        config_source_section = _config_navigate(config_source, section)
+
+        for option in raw_config.options(section):
+            value = raw_config.get(section, option)
+
+            if value.lower() in ['yes', 'true', 'on']:
+                value = True
+            elif value.lower() in ['no', 'false', 'off']:
+                value = False
+            elif value.lower() in ['none']:
+                continue
+            elif value.replace('.', '').isdigit():
+                if '.' in value:
+                    value = Decimal(value)
+                else:
+                    value = int(value)
+
+            config_section[option] = value
+            config_source_section[option] = 'config_file'
 
 
 def _collect_config_sections(section: 'Configuration', prefix: str = '') -> Generator[Tuple[str, str, Any], None, None]:

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -36,7 +36,7 @@ R = TypeVar("R")
 class MILC(object):
     """MILC - An Opinionated Batteries Included Framework
     """
-    def __init__(self, name: Optional[str] = None, author: Optional[str] = None, version: Optional[str] = None, logger: Optional[logging.Logger] = None, env_prefix: Optional[str] = None) -> None:
+    def __init__(self, name: Optional[str] = None, author: Optional[str] = None, version: Optional[str] = None, logger: Optional[logging.Logger] = None, env_prefix: Optional[str] = None, config_file: Optional[Union[str, Path]] = None) -> None:
         """Initialize the MILC object.
         """
         # Set some defaults
@@ -66,6 +66,8 @@ class MILC(object):
         self._initialized = False
         self.ansi = ansi_colors
         self.arg_only: Dict[str, List[str]] = {}
+        self._config_file_explicit = _in_argv('--config-file')
+        self.system_config_file = Path(config_file).expanduser().resolve() if config_file is not None else None
         self.config_file = self.find_config_file()
         self.default_arguments: Dict[str, Dict[str, Optional[str]]] = {}
         self.env_prefix = env_prefix
@@ -538,9 +540,13 @@ class MILC(object):
         config = Configuration()
         config_source = Configuration()
 
-        if self.config_file.exists():
+        config_files = [self.config_file] if self._config_file_explicit else [config_file for config_file in (self.system_config_file, self.config_file) if config_file is not None]
+        for config_file in config_files:
+            if not config_file.exists():
+                continue
+
             raw_config = RawConfigParser()
-            raw_config.read(str(self.config_file))
+            raw_config.read(str(config_file))
 
             # Iterate over the config file options and write them into config.
             # Section names may be dotted (e.g. [remote.add]) for nested subcommands.
@@ -627,9 +633,12 @@ class MILC(object):
 
         self.release_lock()
 
-    def _save_config_file(self, config: Configuration) -> None:
+    def _save_config_file(self, config: Configuration, config_file: Optional[Path] = None) -> None:
         """Write config to disk.
         """
+        config_file = config_file or self.config_file
+        config_dir = config_file.parent
+
         # Generate a sanitized version of our running configuration.
         # _collect_config_sections recurses into nested ConfigurationSection objects,
         # emitting (dotted_section_name, option_name, value) for every leaf.
@@ -641,21 +650,21 @@ class MILC(object):
             if config_source_section[option_name] == 'config_file' and value is not None:
                 sane_config.set(section_name, option_name, str(value))
 
-        if not self.config_dir.exists():
-            self.config_dir.mkdir(parents=True, exist_ok=True)
+        if not config_dir.exists():
+            config_dir.mkdir(parents=True, exist_ok=True)
 
         # Write the config file atomically.
         self.acquire_lock()
         tmpfile_name = None
         try:
-            with NamedTemporaryFile(mode='w', dir=str(self.config_dir), delete=False) as tmpfile:
+            with NamedTemporaryFile(mode='w', dir=str(config_dir), delete=False) as tmpfile:
                 tmpfile_name = tmpfile.name
                 sane_config.write(tmpfile)
 
             if os.path.getsize(tmpfile_name) > 0:
-                os.replace(tmpfile_name, str(self.config_file))
+                os.replace(tmpfile_name, str(config_file))
             else:
-                self.log.warning('Config file saving failed, not replacing %s with %s.', str(self.config_file), tmpfile_name)
+                self.log.warning('Config file saving failed, not replacing %s with %s.', str(config_file), tmpfile_name)
         finally:
             try:
                 if tmpfile_name and os.path.exists(tmpfile_name):
@@ -682,18 +691,19 @@ class MILC(object):
         # Housekeeping
         self.log.info('Wrote configuration to %s', shlex.quote(str(self.config_file)))
 
-    def save_config(self) -> None:
-        """Save the current configuration to the config file.
+    def save_config(self, config_file: Optional[Union[str, Path]] = None) -> None:
+        """Save the current configuration to the config file or an explicit path.
         """
-        self.log.debug("Saving config file to '%s'", str(self.config_file))
+        save_path = Path(config_file).expanduser().resolve() if config_file is not None else self.config_file
+        self.log.debug("Saving config file to '%s'", str(save_path))
 
-        if not self.config_file:
+        if not save_path:
             self.log.warning('%s.config_file file not set, not saving config!', self.__class__.__name__)
             return
 
         # Write config to disk
-        self._save_config_file(self.config)
-        self.log.info('Wrote configuration to %s', shlex.quote(str(self.config_file)))
+        self._save_config_file(self.config, save_path)
+        self.log.info('Wrote configuration to %s', shlex.quote(str(save_path)))
 
     def check_deprecated(self) -> None:
         entry_name = getattr(self._entrypoint, '__name__')

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -540,7 +540,15 @@ class MILC(object):
         config = Configuration()
         config_source = Configuration()
 
-        config_files = [self.config_file] if self._config_file_explicit else [config_file for config_file in (self.system_config_file, self.config_file) if config_file is not None]
+        config_files = []
+        
+        if self._config_file_explicit:
+            config_files.append(self.config_file)
+        else:
+            for config_file in (self.system_config_file, self.config_file):
+                if config_file:
+                    config_files.append(config_file)
+
         for config_file in config_files:
             if not config_file.exists():
                 continue

--- a/milc/milc.py
+++ b/milc/milc.py
@@ -6,7 +6,6 @@ import shlex
 import subprocess
 import sys
 from configparser import RawConfigParser
-from decimal import Decimal
 from pathlib import Path
 from platform import platform
 from tempfile import NamedTemporaryFile
@@ -27,7 +26,7 @@ from typing_extensions import ParamSpec
 from ._in_argv import _in_argv, _index_argv
 from .ansi import MILCFormatter, ansi_colors, ansi_config, ansi_escape, format_ansi
 from .attrdict import AttrDict
-from .configuration import Configuration, SubparserWrapper, _collect_config_sections, _config_navigate, get_argument_name, get_argument_strings, handle_store_boolean
+from .configuration import Configuration, SubparserWrapper, _collect_config_sections, _config_navigate, _read_config_file, get_argument_name, get_argument_strings, handle_store_boolean
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -539,9 +538,8 @@ class MILC(object):
         """
         config = Configuration()
         config_source = Configuration()
-
         config_files = []
-        
+
         if self._config_file_explicit:
             config_files.append(self.config_file)
         else:
@@ -553,33 +551,7 @@ class MILC(object):
             if not config_file.exists():
                 continue
 
-            raw_config = RawConfigParser()
-            raw_config.read(str(config_file))
-
-            # Iterate over the config file options and write them into config.
-            # Section names may be dotted (e.g. [remote.add]) for nested subcommands.
-            for section in raw_config.sections():
-                config_section = _config_navigate(config, section)
-                config_source_section = _config_navigate(config_source, section)
-
-                for option in raw_config.options(section):
-                    value = raw_config.get(section, option)
-
-                    # Coerce values into useful datatypes
-                    if value.lower() in ['yes', 'true', 'on']:
-                        value = True
-                    elif value.lower() in ['no', 'false', 'off']:
-                        value = False
-                    elif value.lower() in ['none']:
-                        continue
-                    elif value.replace('.', '').isdigit():
-                        if '.' in value:
-                            value = Decimal(value)
-                        else:
-                            value = int(value)
-
-                    config_section[option] = value
-                    config_source_section[option] = 'config_file'
+            _read_config_file(config_file, config, config_source)
 
         return config, config_source
 
@@ -646,11 +618,12 @@ class MILC(object):
         """
         config_file = config_file or self.config_file
         config_dir = config_file.parent
+        sane_config = RawConfigParser()
+        tmpfile_name = None
 
         # Generate a sanitized version of our running configuration.
         # _collect_config_sections recurses into nested ConfigurationSection objects,
         # emitting (dotted_section_name, option_name, value) for every leaf.
-        sane_config = RawConfigParser()
         for section_name, option_name, value in _collect_config_sections(config):
             if not sane_config.has_section(section_name):
                 sane_config.add_section(section_name)
@@ -663,7 +636,7 @@ class MILC(object):
 
         # Write the config file atomically.
         self.acquire_lock()
-        tmpfile_name = None
+
         try:
             with NamedTemporaryFile(mode='w', dir=str(config_dir), delete=False) as tmpfile:
                 tmpfile_name = tmpfile.name
@@ -703,14 +676,17 @@ class MILC(object):
         """Save the current configuration to the config file or an explicit path.
         """
         save_path = Path(config_file).expanduser().resolve() if config_file is not None else self.config_file
+
         self.log.debug("Saving config file to '%s'", str(save_path))
 
         if not save_path:
             self.log.warning('%s.config_file file not set, not saving config!', self.__class__.__name__)
+
             return
 
         # Write config to disk
         self._save_config_file(self.config, save_path)
+
         self.log.info('Wrote configuration to %s', shlex.quote(str(save_path)))
 
     def check_deprecated(self) -> None:

--- a/milc/milc_interface.py
+++ b/milc/milc_interface.py
@@ -27,8 +27,9 @@ class MILCInterface:
         self._version: Optional[str] = None
         self._logger: Optional[Logger] = None
         self._env_prefix: Optional[str] = None
+        self._config_file: Optional[Union[str, Path]] = None
 
-    def milc_options(self, *, name: Optional[str] = None, author: Optional[str] = None, version: Optional[str] = None, logger: Optional[Logger] = None, env_prefix: Optional[str] = None) -> None:
+    def milc_options(self, *, name: Optional[str] = None, author: Optional[str] = None, version: Optional[str] = None, logger: Optional[Logger] = None, env_prefix: Optional[str] = None, config_file: Optional[Union[str, Path]] = None) -> None:
         """Configure MILC before the entrypoint runs.
 
         Call this before `cli()` or any imports that reference `cli`. It may be called multiple times; each call updates only the supplied arguments.
@@ -39,6 +40,7 @@ class MILCInterface:
             version: The version string reported by `--version`.
             logger: A custom logger instance to use instead of MILC's default logger.
             env_prefix: A string prefix that enables environment variable defaults. When set, each `--flag` can be configured via a `<PREFIX>_<FLAG>` environment variable.
+            config_file: A system configuration file to read before the platformdirs user configuration file.
         """
         if self._milc and self._milc._initialized:
             raise RuntimeError('You must run cli.milc_options() before cli() or anything else!')
@@ -53,7 +55,9 @@ class MILCInterface:
             self._logger = logger
         if env_prefix is not None:
             self._env_prefix = env_prefix
-        self._milc = MILC(self._name, self._author, self._version, self._logger, self._env_prefix)
+        if config_file is not None:
+            self._config_file = config_file
+        self._milc = MILC(self._name, self._author, self._version, self._logger, self._env_prefix, self._config_file)
 
     @property
     def milc(self) -> MILC:
@@ -184,10 +188,10 @@ class MILCInterface:
         """
         return self.milc.argument(*args, **kwargs)
 
-    def save_config(self) -> None:
-        """Save the current configuration to the config file.
+    def save_config(self, config_file: Optional[Union[str, Path]] = None) -> None:
+        """Save the current configuration to the config file or an explicit path.
         """
-        return self.milc.save_config()
+        return self.milc.save_config(config_file)
 
     def __call__(self) -> Any:
         """Execute the entrypoint function.

--- a/milc/subcommand/config.py
+++ b/milc/subcommand/config.py
@@ -114,6 +114,7 @@ def _process_config_token(config_token: str) -> bool:
 
 
 @milc.cli.argument('-a', '--all', action='store_true', help='Show all configuration options.')
+@milc.cli.argument('-o', '--output', arg_only=True, help='Write the current configuration to this file.')
 @milc.cli.argument('-ro', '--read-only', arg_only=True, action='store_true', help='Operate in read-only mode.')
 @milc.cli.argument('configs', nargs='*', arg_only=True, help='Configuration options to read or write.')
 @milc.cli.subcommand("Read and write configuration settings.")
@@ -138,6 +139,9 @@ def config(cli: MILC) -> bool:
     """
     if not milc.cli.args.configs:
         show_config()
+        if milc.cli.args.output:
+            milc.cli.save_config(milc.cli.args.output)
+            return True
         return False
 
     results = [_process_config_token(token) for token in milc.cli.args.configs]
@@ -145,5 +149,8 @@ def config(cli: MILC) -> bool:
 
     if save_config:
         milc.cli.save_config()
+
+    if milc.cli.args.output:
+        milc.cli.save_config(milc.cli.args.output)
 
     return True

--- a/milc/subcommand/config.py
+++ b/milc/subcommand/config.py
@@ -139,15 +139,17 @@ def config(cli: MILC) -> bool:
     """
     if not milc.cli.args.configs:
         show_config()
+
         if milc.cli.args.output:
             milc.cli.save_config(milc.cli.args.output)
+
             return True
+
         return False
 
     results = [_process_config_token(token) for token in milc.cli.args.configs]
-    save_config = any(results)
 
-    if save_config:
+    if any(results):
         milc.cli.save_config()
 
     if milc.cli.args.output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ ignore = ["E226", "E501"]
 [tool.ruff.lint.mccabe]
 max-complexity = 12
 
+[tool.yapfignore]
+ignore_patterns = [
+  ".*/**",
+]
+
 [tool.yapf]
 align_closing_bracket_with_visual_indent = true
 allow_multiline_dictionary_keys = false

--- a/tests/test_config_file_search.py
+++ b/tests/test_config_file_search.py
@@ -85,8 +85,7 @@ def test_config_output_exports_without_writing_platformdirs_config(tmp_path):
     _create_config_file(system_config_file, '[general]\nsource = system\n')
     output_config_file = tmp_path / 'output.ini'
     script = tmp_path / 'application.py'
-    script.write_text(
-        """
+    script.write_text("""
 import os
 
 from milc import cli
@@ -103,9 +102,7 @@ def main(cli):
 
 if __name__ == '__main__':
     cli()
-""".strip()
-        + '\n'
-    )
+""".strip() + '\n')
     environment = {**os.environ, 'SYSTEM_CONFIG': str(system_config_file), 'XDG_CONFIG_HOME': str(tmp_path / 'platformdirs')}
 
     result = subprocess.run([sys.executable, str(script), 'config', '--output', str(output_config_file)], capture_output=True, text=True, env=environment)

--- a/tests/test_config_file_search.py
+++ b/tests/test_config_file_search.py
@@ -1,0 +1,117 @@
+"""Tests for layered configuration file handling."""
+import os
+import subprocess
+import sys
+from configparser import RawConfigParser
+
+import milc
+
+
+def _create_config_file(path, contents):
+    path.write_text(contents)
+
+
+def _create_milc(monkeypatch, tmp_path, system_config_file=None, argv=None):
+    platform_config_dir = tmp_path / 'platformdirs'
+    monkeypatch.setattr(sys, 'argv', argv or ['application'])
+    monkeypatch.setattr(milc.milc, 'user_config_dir', lambda **kwargs: str(platform_config_dir))
+    return milc.milc.MILC(name='application', config_file=system_config_file), platform_config_dir / 'application.ini'
+
+
+def test_platformdirs_config_overrides_and_merges_system_config(monkeypatch, tmp_path):
+    system_config_file = tmp_path / 'system.ini'
+    _create_config_file(system_config_file, '[general]\nshared = system\nsystem_only = yes\n')
+    platform_config_dir = tmp_path / 'platformdirs'
+    platform_config_dir.mkdir()
+    _create_config_file(platform_config_dir / 'application.ini', '[general]\nshared = user\nuser_only = 42\n')
+    monkeypatch.setattr(sys, 'argv', ['application'])
+    monkeypatch.setattr(milc.milc, 'user_config_dir', lambda **kwargs: str(platform_config_dir))
+
+    cli = milc.milc_interface.MILCInterface()
+    cli.milc_options(name='application', config_file=system_config_file)
+
+    assert cli.milc.config_file == (platform_config_dir / 'application.ini').resolve()
+    assert cli.config.general.shared == 'user'
+    assert cli.config.general.system_only is True
+    assert cli.config.general.user_only == 42
+
+
+def test_missing_system_config_still_loads_platformdirs_config(monkeypatch, tmp_path):
+    platform_config_dir = tmp_path / 'platformdirs'
+    platform_config_dir.mkdir()
+    platform_config_file = platform_config_dir / 'application.ini'
+    _create_config_file(platform_config_file, '[general]\nsource = user\n')
+
+    milc, _ = _create_milc(monkeypatch, tmp_path, tmp_path / 'missing-system.ini')
+
+    assert milc.config_file == platform_config_file.resolve()
+    assert milc.config.general.source == 'user'
+
+
+def test_normal_save_writes_merged_config_to_platformdirs(monkeypatch, tmp_path):
+    system_config_file = tmp_path / 'system.ini'
+    _create_config_file(system_config_file, '[general]\nsystem_only = system\n')
+    platform_config_dir = tmp_path / 'platformdirs'
+    platform_config_dir.mkdir()
+    platform_config_file = platform_config_dir / 'application.ini'
+    _create_config_file(platform_config_file, '[general]\nuser_only = user\n')
+
+    milc, _ = _create_milc(monkeypatch, tmp_path, system_config_file)
+    milc.save_config()
+
+    saved_config = RawConfigParser()
+    saved_config.read(platform_config_file)
+    assert saved_config.get('general', 'system_only') == 'system'
+    assert saved_config.get('general', 'user_only') == 'user'
+
+
+def test_command_line_config_file_bypasses_system_and_platformdirs_configs(monkeypatch, tmp_path):
+    system_config_file = tmp_path / 'system.ini'
+    _create_config_file(system_config_file, '[general]\nsource = system\n')
+    platform_config_dir = tmp_path / 'platformdirs'
+    platform_config_dir.mkdir()
+    _create_config_file(platform_config_dir / 'application.ini', '[general]\nsource = user\n')
+    command_line_config_file = tmp_path / 'command-line.ini'
+    _create_config_file(command_line_config_file, '[general]\nsource = command-line\n')
+
+    milc, _ = _create_milc(monkeypatch, tmp_path, system_config_file, ['application', '--config-file', str(command_line_config_file)])
+
+    assert milc.config_file == command_line_config_file.resolve()
+    assert milc.config.general.source == 'command-line'
+
+
+def test_config_output_exports_without_writing_platformdirs_config(tmp_path):
+    system_config_file = tmp_path / 'system.ini'
+    _create_config_file(system_config_file, '[general]\nsource = system\n')
+    output_config_file = tmp_path / 'output.ini'
+    script = tmp_path / 'application.py'
+    script.write_text(
+        """
+import os
+
+from milc import cli
+
+cli.milc_options(name='application', config_file=os.environ['SYSTEM_CONFIG'])
+
+import milc.subcommand.config
+
+
+@cli.entrypoint('Test application.')
+def main(cli):
+    pass
+
+
+if __name__ == '__main__':
+    cli()
+""".strip()
+        + '\n'
+    )
+    environment = {**os.environ, 'SYSTEM_CONFIG': str(system_config_file), 'XDG_CONFIG_HOME': str(tmp_path / 'platformdirs')}
+
+    result = subprocess.run([sys.executable, str(script), 'config', '--output', str(output_config_file)], capture_output=True, text=True, env=environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    exported_config = RawConfigParser()
+    exported_config.read(output_config_file)
+    assert exported_config.get('general', 'source') == 'system'
+    assert not (tmp_path / 'platformdirs' / 'application' / 'application.ini').exists()


### PR DESCRIPTION
## Summary
- load an optional system config before the platformdirs user config
- keep platformdirs as the normal save target and preserve standalone `--config-file` behavior
- add `config --output/-o` for exporting configuration

## Testing
- `uv run pytest`
- `uv run ruff check milc/milc.py milc/milc_interface.py milc/subcommand/config.py tests/test_config_file_search.py`