### PR TITLE
fix: Move types-colorama to [dev] group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "halo",
     "platformdirs",
     "spinners",
-    "types-colorama",
     "typing_extensions",
 ]
 
@@ -52,6 +51,7 @@ dev = [
     "mkdocs-git-revision-date-plugin",
     "mkdocs-material<9",
     "ty",
+    "types-colorama",
     "pydoc-markdown",
     "pytest",
     "pygments",


### PR DESCRIPTION
A typing stub is not a runtime necessity, but it sure aids development, so move it to the dev group.

Arch Linux ships `milc` without a dependency on the typing stub, so it currently fails `pip check`.

EDIT: If you could generate the docs to make CI happy, that'd be neat, `pydoc-markdown` isn't packaged for my system.